### PR TITLE
Add env token for Marktplaats API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ pip install -r marktplaats-backend/requirements.txt
 
 **Deploy to AWS:**
 ```bash
+export MARKTPLAATS_TOKEN=your_api_token
 cd marktplaats-backend
 serverless deploy
 ```
@@ -63,3 +64,6 @@ The following utility modules are imported but not present in the codebase:
 Update the S3 bucket name in both:
 - `generate_listing_lambda.py:9` (`s3_bucket` variable)
 - `serverless_backend.yaml:10` (`S3_BUCKET` environment variable)
+
+Set your Marktplaats API token via the `MARKTPLAATS_TOKEN` environment
+variable so that `category_matcher.py` can authenticate to the API.

--- a/marktplaats-backend/category_matcher.py
+++ b/marktplaats-backend/category_matcher.py
@@ -1,9 +1,10 @@
+import os
 import requests
 from difflib import get_close_matches
 
 MARKTPLAATS_API_BASE = "https://api.marktplaats.nl/v1"
 MARKTPLAATS_AUTH_HEADER = {
-    "Authorization": "Bearer YOUR_ACCESS_TOKEN",  # Replace with actual token securely
+    "Authorization": f"Bearer {os.environ['MARKTPLAATS_TOKEN']}",
     "Accept-Language": "nl-NL"  # 👈 Ensures Dutch category names
 }
 

--- a/marktplaats-backend/serverless.yaml
+++ b/marktplaats-backend/serverless.yaml
@@ -8,6 +8,7 @@ provider:
   timeout: 30
   environment:
     S3_BUCKET: marktplaatser-images
+    MARKTPLAATS_TOKEN: ${env:MARKTPLAATS_TOKEN}
   iam:
     role:
       statements:


### PR DESCRIPTION
## Summary
- load Marktplaats token from environment in category_matcher
- expose MARKTPLAATS_TOKEN in serverless config
- document env variable in CLAUDE deployment instructions

## Testing
- `python -m py_compile marktplaats-backend/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685943a559d88327a9056c6727df43c1