### PR TITLE
Add Marktplaats posting lambda

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ This is a serverless AWS Lambda application for generating marketplace listings 
 
 **Core Components:**
 - `generate_listing_lambda.py` - Main Lambda handler that orchestrates the image processing pipeline
+- `place_listing_lambda.py` - Posts the generated listing to the Marktplaats API
 - `rekognition_utils.py` - AWS Rekognition integration for image analysis (label detection and text extraction)
 - The serverless configuration references a `handler.py` module that is not present.
 
@@ -41,7 +42,8 @@ pip install -r marktplaats-backend/requirements.txt
 
 **Deploy to AWS:**
 ```bash
-export MARKTPLAATS_TOKEN=your_api_token
+export MARKTPLAATS_CLIENT_ID=your_client_id
+export MARKTPLAATS_CLIENT_SECRET=your_client_secret
 cd marktplaats-backend
 ./deploy.sh
 ```
@@ -71,6 +73,7 @@ Update the S3 bucket name in both:
 - `generate_listing_lambda.py:9` (`s3_bucket` variable)
 - `serverless.yaml:10` (`S3_BUCKET` environment variable)
 
-Set your Marktplaats API token via the `MARKTPLAATS_TOKEN` environment
-variable so that `category_matcher.py` can authenticate to the API.
+Set your Marktplaats API credentials via the `MARKTPLAATS_CLIENT_ID` and
+`MARKTPLAATS_CLIENT_SECRET` environment variables so that the lambdas can
+authenticate to the API.
 

--- a/marktplaats-backend/place_listing_lambda.py
+++ b/marktplaats-backend/place_listing_lambda.py
@@ -1,0 +1,33 @@
+import json
+import requests
+
+from marktplaats_auth import get_marktplaats_access_token
+
+MARKTPLAATS_API_BASE = "https://api.marktplaats.nl/v1"
+
+
+def create_marktplaats_listing(listing):
+    """Send the listing data to the Marktplaats API."""
+    token = get_marktplaats_access_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+        "Accept-Language": "nl-NL",
+    }
+    response = requests.post(
+        f"{MARKTPLAATS_API_BASE}/listings",
+        headers=headers,
+        json=listing,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def lambda_handler(event, context):
+    try:
+        body = json.loads(event["body"])
+        result = create_marktplaats_listing(body)
+        return {"statusCode": 200, "body": json.dumps(result)}
+    except Exception as e:
+        return {"statusCode": 500, "body": json.dumps({"error": str(e)})}

--- a/marktplaats-backend/serverless.yaml
+++ b/marktplaats-backend/serverless.yaml
@@ -39,6 +39,13 @@ functions:
           path: generate-listing
           method: post
           cors: true
+  placeListing:
+    handler: place_listing_lambda.lambda_handler
+    events:
+      - http:
+          path: place-listing
+          method: post
+          cors: true
 
 plugins:
   - serverless-python-requirements


### PR DESCRIPTION
## Summary
- implement `place_listing_lambda.py` that calls the Marktplaats API to create a listing
- expose the new lambda through serverless configuration
- document the new component and updated API credentials in `CLAUDE.md`

## Testing
- `pytest -q`
- `python -m py_compile marktplaats-backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685aee57429c83278fc073708bf094a4